### PR TITLE
Update version number in C++ code

### DIFF
--- a/vlevel-bin/vlevel-bin.cpp
+++ b/vlevel-bin/vlevel-bin.cpp
@@ -120,7 +120,7 @@ void LevelRaw(FILE *in, FILE *out, VolumeLeveler &vl, unsigned int bits_per_valu
 
 void Help()
 {
-	cerr << "VLevel v0.5" << endl
+	cerr << "VLevel v0.5.1" << endl
 	     << endl
 	     << "usage:" << endl
 	     << "\tvlevel-bin [options] < infile > outfile" << endl

--- a/vlevel-jack/vlevel-jack.cpp
+++ b/vlevel-jack/vlevel-jack.cpp
@@ -92,7 +92,7 @@ void jack_shutdown(void *arg)
 
 void vlevel_help()
 {
-    cerr << "VLevel v0.5 JACK edition" << endl
+    cerr << "VLevel v0.5.1 JACK edition" << endl
          << endl
          << "usage:" << endl
          << "\tvlevel-bin [options] < infile > outfile" << endl


### PR DESCRIPTION
Version 0.5.1 of vlevel-bin and vlevel-jack still output "v0.5" as version. This commit fixes this. (But likely needs to be updated for 0.5.2 or 0.6 or whatever is comming next.)
