### PR TITLE
vlevel-jack shouldn't try to connect to jackd if passed -h or --help

### DIFF
--- a/vlevel-jack/vlevel-jack.cpp
+++ b/vlevel-jack/vlevel-jack.cpp
@@ -170,7 +170,7 @@ int vlevel_parse_options(
             undo = true;
         } else if(option == "help" || option == "h") {
             vlevel_help();
-            return 0;
+            exit(0);
         } else {
             cerr << cmd.GetProgramName() << ": unrecognized option " << option << endl;
             vlevel_help();


### PR DESCRIPTION
Hi,

thanks for continuing vlevel. I'm [packaging vlevel for Debian](https://tracker.debian.org/pkg/vlevel).

When trying to update the package for 0.5.1, I noticed that vlevel-jack tries to connect to jackd even if I pass `-h` or `--help`

```
$ vlevel-jack -h
VLevel v0.5 JACK edition

usage:
        vlevel-bin [options] < infile > outfile

options: (abbreviations also work)
        --length num
                Size of the lookahead buffer. The longer, the slowest
                Default is 512
        --channels num
                Each sample has num channels
                Default is 2
        --strength num
                Effect strength, 1 is max, 0 is no effect.
                Default is .8
        --max-multiplier num
                Sets the maximum amount a sample will be multiplied
                Default is 20
        --undo
                Reverses the effect of a previous VLevel
Beginning VLevel with:
channels:       2
strength:       0.8
max_multiplier: 20
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
exec of JACK server (command = "/usr/bin/jackd") failed: No such file or directory
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
^C
```

This does not happen if it is passed an unknown option like e.g. `--version`:

```
$ vlevel-jack --version
vlevel-jack: unrecognized option version
VLevel v0.5 JACK edition

usage:
        vlevel-bin [options] < infile > outfile

options: (abbreviations also work)
        --length num
                Size of the lookahead buffer. The longer, the slowest
                Default is 512
        --channels num
                Each sample has num channels
                Default is 2
        --strength num
                Effect strength, 1 is max, 0 is no effect.
                Default is .8
        --max-multiplier num
                Sets the maximum amount a sample will be multiplied
                Default is 20
        --undo
                Reverses the effect of a previous VLevel
$
```
